### PR TITLE
Fix #17 - improve cursor behavior on label hovering

### DIFF
--- a/src/lib/components/Label.svelte
+++ b/src/lib/components/Label.svelte
@@ -37,7 +37,7 @@
         border-radius: 16px;
         text-decoration: none;
         font-weight: 500;
-        cursor: default;
+        cursor: inherit;
         text-align: center;
         border: none;
         font-family: inherit;

--- a/src/lib/components/LableTableEntry.svelte
+++ b/src/lib/components/LableTableEntry.svelte
@@ -96,6 +96,7 @@
 <style>
     .entry-container {
         display: grid;
+        cursor: default;
         grid-template-columns: 1fr 2fr 120px;
         gap: 1rem;
         padding: 1rem 1.5rem;


### PR DESCRIPTION
close #17 

Also fix an undetected issue where the description of a label had the wrong cursor in the /label page