### PR TITLE
Fix #48 Items maxsize on many labels

### DIFF
--- a/src/lib/components/LabelList.svelte
+++ b/src/lib/components/LabelList.svelte
@@ -1,23 +1,71 @@
 <script lang="ts">
     import Label from './Label.svelte';
     import type { LabelModel } from '$lib/api';
+    import { onMount } from "svelte";
 
     interface Props {
         labels: LabelModel[];
         size?: 'small' | 'medium' | 'large';
+        container?: HTMLElement;
     }
 
-    let { labels, size = 'small' }: Props = $props();
+    let { labels, size = 'small', container }: Props = $props();
 
-    let sortedLabels = $derived(labels.sort((a, b) => a.title.length - b.title.length))
+    let sortedLabels = $derived(labels.sort((a, b) => a.title.length - b.title.length));
+    let visibleLabels = $state<LabelModel[]>([]);
+    let hiddenCount = $state(0);
+
+    function updateVisible() {
+        if (!container) return;
+
+        const parentWidth = container.clientWidth;
+        let currentWidth = 0;
+        let shown = [];
+
+        const div = document.createElement("div");
+        div.style.position = "absolute";
+        div.style.visibility = "hidden";
+
+        document.body.appendChild(div);
+
+        for (let label of sortedLabels) {
+            const labelSpan = document.createElement("span");
+            labelSpan.textContent = label.title;
+            div.appendChild(labelSpan);
+
+            const w = labelSpan.getBoundingClientRect().width;
+            if (currentWidth + w <= parentWidth) {
+                shown.push(label);
+                currentWidth += w;
+            } else {
+                break;
+            }
+        }
+
+        document.body.removeChild(div);
+
+        visibleLabels = shown;
+        hiddenCount = sortedLabels.length - shown.length;
+    }
+
+    onMount(() => {
+        if (!container) return;
+        updateVisible();
+        const resizeObs = new ResizeObserver(updateVisible);
+        resizeObs.observe(container);
+    });
+
 </script>
 
 <div class="label-list">
-    {#each sortedLabels as label (label.id)}
+    {#each visibleLabels as label (label.id)}
         <Label color={label.color} {size}>
             {label.title}
         </Label>
     {/each}
+    {#if hiddenCount > 0}
+        <span class="px-2 py-1 bg-red-200 rounded">+{hiddenCount}</span>
+    {/if}
 </div>
 
 <style>

--- a/src/lib/components/LabelList.svelte
+++ b/src/lib/components/LabelList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import Label from './Label.svelte';
     import type { LabelModel } from '$lib/api';
-    import { onMount } from "svelte";
+    import { onMount, tick } from "svelte";
 
     interface Props {
         labels: LabelModel[];
@@ -12,47 +12,48 @@
     let { labels, size = 'small', container }: Props = $props();
 
     let sortedLabels = $derived(labels.sort((a, b) => a.title.length - b.title.length));
-    let visibleLabels = $state<LabelModel[]>([]);
-    let hiddenCount = $state(0);
+    let showedCount = $state(0);
+    let hiddenCount = $derived(sortedLabels.length - showedCount);
+    let visibleLabels = $derived(sortedLabels.slice(0, showedCount));
+    let measurementContainer: HTMLDivElement;
 
     function updateVisible() {
-        if (!container) return;
+        if (!container || !measurementContainer) return;
 
         const parentWidth = container.clientWidth;
+        
         let currentWidth = 0;
-        let shown = [];
+        showedCount = 0;
 
-        const div = document.createElement("div");
-        div.style.position = "absolute";
-        div.style.visibility = "hidden";
+        const measurementLabels = measurementContainer.children;
 
-        document.body.appendChild(div);
-
-        for (let label of sortedLabels) {
-            const labelSpan = document.createElement("span");
-            labelSpan.textContent = label.title;
-            div.appendChild(labelSpan);
-
-            const w = labelSpan.getBoundingClientRect().width;
+        for (let i = 0; i < sortedLabels.length && i < measurementLabels.length; i++) {
+            const labelElement = measurementLabels[i] as HTMLElement;
+            
+            const w = labelElement.getBoundingClientRect().width;
             if (currentWidth + w <= parentWidth) {
-                shown.push(label);
+                showedCount = showedCount + 1;
                 currentWidth += w;
             } else {
                 break;
             }
         }
-
-        document.body.removeChild(div);
-
-        visibleLabels = shown;
-        hiddenCount = sortedLabels.length - shown.length;
     }
 
-    onMount(() => {
-        if (!container) return;
-        updateVisible();
-        const resizeObs = new ResizeObserver(updateVisible);
-        resizeObs.observe(container);
+    onMount(async () => {
+        await tick(); // ensure DOM is loaded
+        const checkAndUpdate = () => {
+            if (measurementContainer) {
+                updateVisible();
+                const resizeObs = new ResizeObserver(updateVisible);
+                if (!container) return;
+                resizeObs.observe(container);
+            } else {
+                requestAnimationFrame(checkAndUpdate);
+            }
+        };
+        
+        checkAndUpdate();
     });
 
 </script>
@@ -64,7 +65,19 @@
         </Label>
     {/each}
     {#if hiddenCount > 0}
-        <span class="px-2 py-1 bg-red-200 rounded">+{hiddenCount}</span>
+        <span class="label-overflow">+{hiddenCount}</span>
+    {/if}
+</div>
+
+<!-- Hidden measurement container -->
+<div bind:this={measurementContainer} class="measurement-container label-list">
+    {#each sortedLabels as label (label.id)}
+        <Label color={label.color} {size}>
+            <span class="measurement-label">{label.title}</span>
+        </Label>
+    {/each}
+    {#if hiddenCount > 0}
+        <span class="label-overflow measurement-label">+{hiddenCount}</span>
     {/if}
 </div>
 
@@ -76,15 +89,48 @@
         align-items: center;
     }
 
+    .label-overflow {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.75rem;
+        font-family: inherit;
+        text-align: center;
+        background: #f3f4f6;
+        padding: 0.2rem 0.5rem;
+        border-radius: 16px;
+        border: 1px solid #e5e7eb;
+        transition: all 0.2s ease;
+    }
+
+    .label-overflow:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+
+    .measurement-container {
+        position: absolute;
+        top: -9999px;
+        left: -9999px;
+        visibility: hidden;
+        pointer-events: none;
+    }
+
+    .measurement-label {
+        padding: 0.25rem 0.6rem;
+        font-size: 0.75rem;
+        white-space: nowrap;
+    }
+
     @media (max-width: 640px) {
         .label-list {
-            gap: 0.25rem;
+            gap: 0.2rem;
         }
     }
 
     @media (max-width: 480px) {
         .label-list {
-            gap: 0.25rem;
+            gap: 0.2rem;
         }
     }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -597,6 +597,15 @@
 			text-align: center;
 		}
 
+		.hero-content {
+			max-width: 100%;
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			flex-direction: column;
+			padding: 1rem 3rem;
+		}
+
 		.hero-title {
 			font-size: 2.5rem;
 		}
@@ -622,6 +631,12 @@
 			flex-direction: column;
 			align-items: center;
 		}
+
+		.box-icons {
+			flex-direction: row;
+			justify-content: center;
+			flex-wrap: wrap;
+		}
 	}
 
 	@media (max-width: 480px) {
@@ -631,6 +646,15 @@
 		
 		.dashboard-title {
 			font-size: 1.75rem;
+		}
+
+		.box-icons {
+			flex-direction: column;
+			justify-content: center;
+		}
+
+		.hero-content {
+			padding: 0;
 		}
 	}
 </style>

--- a/src/routes/box/[boxId]/items/+page.svelte
+++ b/src/routes/box/[boxId]/items/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
-	import { isAuthenticated, currentUser } from '$lib/stores/auth';
+	import { isAuthenticated } from '$lib/stores/auth';
 	import { getBoxItems, getBoxes, type Item, type Box } from '$lib/api';
 	import { Button, Card, Alert, LabelList } from '$lib';
 	import { translateStore } from '$lib/strings';
@@ -22,6 +22,7 @@
 	let showUpdateModal = false;
 	let showItemUpdateModal = false;
 	let modifiedItem: Item | null = null
+	let container;
 
 	async function loadBoxItems() {
 		if (!$isAuthenticated) {
@@ -253,9 +254,9 @@
 										</div>
 										<div class="item-arrow">→</div>
 									</div>
-									<div class="label-container">
+									<div bind:this={container} class="label-container">
 										{#if item.labels && item.labels.length > 0}
-											<LabelList labels={item.labels} size="medium" />
+											<LabelList labels={item.labels} size="medium" container={container} />
 										{/if}
 									</div>
 								</div>
@@ -618,7 +619,7 @@
 		.box-title {
 			font-size: 1.75rem;
 		}
-		
+
 		.empty-items-state {
 			padding: 2rem 1rem;
 			margin: 1rem 0;


### PR DESCRIPTION
close #48 

Here is my best workaround for this issue. It looks very good, but it relies on a small trick: using a hidden div to calculate the width and related values.

I also tried a cleaner approach using events & callbacks, but I ran into several small issues. I’ll add a comment with more details about this second workaround, along with some code snippets, so you can refer to it in the future if you want to make this solution “cleaner.”