### PR TITLE
Fix #41 - remove auth related flash

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -6,6 +6,7 @@ declare global {
 		// interface Locals {}
 		interface Locals {
 			language: string;
+			jwt: string | null;
 		}
 		// interface PageData {}
 		// interface PageState {}

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,15 +1,12 @@
 import { redirect, type ClientInit } from "@sveltejs/kit";
-import { isAuthenticated, currentUser } from '$lib/stores/auth';
-import { getUserProfile, logout } from "$lib";
+import { isAuthenticated} from '$lib/stores/auth';
+import { getUserProfile } from "$lib";
 import { get } from 'svelte/store'
 
 export const init: ClientInit = async () => {
     if (get(isAuthenticated)) {
         try {
-            const user = get(currentUser)
-            if (user?.username) {
-                const profile = await getUserProfile(user.username) 
-            }
+                const profile = await getUserProfile() 
         } catch (error) {
             redirect(300, "/login")
         }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -3,10 +3,13 @@ import { Lang } from '$lib';
 
 export const handle: Handle = async ({ event, resolve }) => {
     const cookieLang = event.cookies.get('language');
+    const cookieJwt = event.cookies.get('jwt')
     
     const userLanguage = cookieLang || Lang.EN;
+    const userToken = cookieJwt || null
     
     event.locals.language = userLanguage;
+    event.locals.jwt = userToken
     
     return resolve(event);
 };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -114,7 +114,22 @@ export async function protectedRequest(url: string, options: RequestInit = {}): 
     return response;
 }
 
-export async function getUserProfile(username: string): Promise<UserProfile> {
+export async function getUserProfile(): Promise<UserProfile> {
+    try {
+        const response = await protectedRequest(`${baseUrl}/api/user`);
+        const apiResponse: APIResponse<UserProfile> = await response.json();
+    
+        if (!apiResponse.success || !apiResponse.data) {
+            throw new Error(apiResponse.error || "Error while fetching user datas");
+        }
+    
+        return apiResponse.data
+    } catch (error: any) {
+        throw new Error(error.message)
+    }
+}
+
+export async function getUserProfileWithUsername(username: string): Promise<UserProfile> {
     try {
         const response = await protectedRequest(`${baseUrl}/api/user/${username}`);
         const apiResponse: APIResponse<UserProfile> = await response.json();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,7 @@
 import { baseUrl } from './index';
 import CryptoJS from 'crypto-js';
+import { get } from 'svelte/store';
+import { userToken } from './index';
 
 export async function unprotectedRequest(url: string, options: RequestInit = {}): Promise<Response> {
     const response = await fetch(url, options);
@@ -85,7 +87,7 @@ export interface UserProfile {
 }
 
 export async function protectedRequest(url: string, options: RequestInit = {}): Promise<Response> {
-    const token = localStorage.getItem('auth_token');
+    const token = get(userToken)
     
     if (!token) {
         throw new Error('No authentication token found');

--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -1,13 +1,9 @@
 import { browser } from '$app/environment';
 import { derived, writable } from 'svelte/store';
-import type { UserProfile } from '../api';
 
 export const userToken = writable<string | null>(null);
-export const currentUser = writable<UserProfile | null>(null);
 export const isHydrationComplete = writable<boolean>(false);
 export const isAuthenticated = derived([userToken, isHydrationComplete], ([$userToken, $isHydrationComplete]) => {
-    // During SSR or before hydration, use the userToken value directly
-    // After hydration, use the reactive userToken
     return !!$userToken;
 });
 
@@ -30,7 +26,6 @@ export function setToken(token: string) {
 
 export function clearAuth(): void {
     userToken.set(null);
-    currentUser.set(null);
     if (browser) {
         // Clear the JWT cookie
         document.cookie = 'jwt=; max-age=0; path=/; SameSite=Lax';

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -4,5 +4,7 @@ export const load = async ({locals}) => {
     return {
         translations: getTranslations(),
         userLanguage: locals.language,
+        userToken: locals.jwt,
+        isAuthenticated: !!locals.jwt, 
     }
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,9 +1,17 @@
 <script lang="ts">
 	import '../app.css';
 	import { page } from '$app/stores';
-	import { isAuthenticated, currentUser } from '$lib/stores/auth';
+	import { isAuthenticated } from '$lib/stores/auth';
 	import { translateStore } from '$lib/strings';
 	import LangSwitcher from '$lib/components/LangSwitcher.svelte';
+
+	interface Props {
+		data: any
+	}
+	
+	let { data }: Props = $props()
+	let serverIsAuthenticated = $derived(data?.isAuthenticated ?? false);
+	let authState = $derived(serverIsAuthenticated || $isAuthenticated);
 </script>
 
 <div class="app">
@@ -17,14 +25,14 @@
 			</div>
 			<div class="nav-links">
 				<LangSwitcher />
-				{#if $isAuthenticated && $currentUser}
+				{#if authState === true}
 					<a href="/" class="nav-link" class:active={$page.url.pathname === '/'}>
 						{$translateStore('boxes')}
 					</a>
 					<a href="/labels" class="nav-link" class:active={$page.url.pathname === '/labels'}>
 						{$translateStore('labels')}
 					</a>
-					<a href="/users/{$currentUser.username}" class="nav-link" class:active={$page.url.pathname.startsWith('/users/')}>
+					<a href="/users/" class="nav-link" class:active={$page.url.pathname.startsWith('/users/')}>
 						{$translateStore('profile')}
 					</a>
 				{:else}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/stores';
 	import { isAuthenticated } from '$lib/stores/auth';
 	import { translateStore } from '$lib/strings';
+	import { getUserProfile } from '$lib';	
 	import LangSwitcher from '$lib/components/LangSwitcher.svelte';
 
 	interface Props {
@@ -12,6 +13,15 @@
 	let { data }: Props = $props()
 	let serverIsAuthenticated = $derived(data?.isAuthenticated ?? false);
 	let authState = $derived(serverIsAuthenticated || $isAuthenticated);
+	let username: string | null = $state(null)
+
+	$effect(() => {
+		if (!username && $isAuthenticated) {
+			getUserProfile().then(userProfile => {
+				username = userProfile.username
+			})
+		}
+	})
 </script>
 
 <div class="app">
@@ -32,7 +42,7 @@
 					<a href="/labels" class="nav-link" class:active={$page.url.pathname === '/labels'}>
 						{$translateStore('labels')}
 					</a>
-					<a href="/users/" class="nav-link" class:active={$page.url.pathname.startsWith('/users/')}>
+					<a href="/users/{username}" class="nav-link" class:active={$page.url.pathname.startsWith('/users/')}>
 						{$translateStore('profile')}
 					</a>
 				{:else}

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,9 +1,18 @@
+import { userToken, setHydrationComplete } from '$lib';
 import { language } from '$lib/stores/lang.js';
 
 export const load = async ({ data }) => {
     if (data?.userLanguage) {
         language.set(data.userLanguage as any);
     }
-    
+
+    if (data?.userToken) {
+        userToken.set(data.userToken)
+    } else {
+        userToken.set(null);
+    }
+
+    setHydrationComplete(true);
+
     return data;
 };

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,0 +1,5 @@
+export const load = async ({locals}) => {
+    return {
+        isAuthenticated: !!locals.jwt,
+    }
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -116,6 +116,7 @@
 {#if authState}
 	<!-- User Dashboard -->
 	<div class="dashboard">
+	{#if !loading}
 		<div class="dashboard-header">
 			<div class="header-content">
 				<h1 class="dashboard-title">
@@ -132,6 +133,7 @@
 				/>
 			</div>
 		</div>
+	{/if}
 
 		{#if loading}
 			<div class="loading-state">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { isAuthenticated, currentUser } from '$lib';
+	import { isAuthenticated } from '$lib';
 	import { goto } from '$app/navigation';
-	import { Button, FeatureCard, BoxCard, Alert, ItemSearch } from '$lib';
+	import { Button, FeatureCard, BoxCard, Alert, ItemSearch, getUserProfile } from '$lib';
 	import CreateBoxModal from '$lib/components/CreateBoxModal.svelte';
 	import { getBoxes, type Box } from '$lib/api';
 	import { translateStore } from '$lib/strings';
@@ -22,6 +22,7 @@
 	let loadingPromise: Promise<void> | null = null;
 	let showCreateModal = $state(false);
 	let hasInitialized = $state(false);
+	let username: string | null = $state(null)
 
 	function openCreateModal() {
 		showCreateModal = true;
@@ -98,6 +99,12 @@
 			loading = false;
 			hasInitialized = true;
 		}
+
+		if (!username && $isAuthenticated) {
+			getUserProfile().then(userProfile => {
+				username = userProfile.username
+			})
+		}
 	})
 </script>
 
@@ -112,7 +119,7 @@
 		<div class="dashboard-header">
 			<div class="header-content">
 				<h1 class="dashboard-title">
-					{$translateStore('welcome_back_dashboard')} <span class="user-name">{$currentUser?.username || $translateStore('user_default')}</span>! 👋
+					{$translateStore('welcome_back_dashboard')} <span class="user-name">{username || $translateStore('user_default')}</span>! 👋
 				</h1>
 				<p class="dashboard-subtitle">{$translateStore('manage_storage_subtitle')}</p>
 			</div>

--- a/src/routes/debug/+page.svelte
+++ b/src/routes/debug/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { isAuthenticated, currentUser, accessToken } from '$lib/stores/auth';
+	import { isAuthenticated} from '$lib/stores/auth';
 	import { browser } from '$app/environment';
 	import { Button, Card, ItemSearch } from '$lib';
 	import { translateStore } from '$lib/strings';
@@ -102,8 +102,8 @@
 	<div class="debug-section">
 		<h2>{$translateStore('svelte_stores')}</h2>
 		<p><strong>isAuthenticated:</strong> {$isAuthenticated}</p>
-		<p><strong>accessToken:</strong> {$accessToken || 'null'}</p>
-		<p><strong>currentUser:</strong> {JSON.stringify($currentUser) || 'null'}</p>
+		<p><strong>accessToken:</strong> { 'null'}</p>
+		<p><strong>currentUser:</strong> {'null'}</p>
 	</div>
 
 	<div class="debug-section">

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { getLabel, login, setToken, setUser } from '$lib';
+	import { login, setToken} from '$lib';
 	import { goto } from '$app/navigation';
 	import { FormInput, Button, Alert, Card } from '$lib';
 	import { setLabels } from '$lib/stores/labels';
@@ -36,15 +36,9 @@
 			// Set token first
 			setToken(token);
 			console.log('Token set in store');
-			
-			// Set user data
-			const userData = { username };
-			setUser(userData);
-			console.log('User set in store:', userData);
-			
+		
 			// Verify localStorage
 			console.log('localStorage auth_token:', localStorage.getItem('auth_token'));
-			console.log('localStorage current_user:', localStorage.getItem('current_user'));
 			
 			// Small delay to ensure stores are updated
 			await new Promise(resolve => setTimeout(resolve, 100));

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -2,7 +2,6 @@
 	import { login, setToken} from '$lib';
 	import { goto } from '$app/navigation';
 	import { FormInput, Button, Alert, Card } from '$lib';
-	import { setLabels } from '$lib/stores/labels';
 	import { translateStore } from '$lib/strings';
 	
 	let username = '';
@@ -33,14 +32,9 @@
 				throw new Error('No token received from server');
 			}
 			
-			// Set token first
 			setToken(token);
 			console.log('Token set in store');
 		
-			// Verify localStorage
-			console.log('localStorage auth_token:', localStorage.getItem('auth_token'));
-			
-			// Small delay to ensure stores are updated
 			await new Promise(resolve => setTimeout(resolve, 100));
 			// Navigate to home page
 			goto('/');

--- a/src/routes/users/[username]/+page.server.ts
+++ b/src/routes/users/[username]/+page.server.ts
@@ -4,13 +4,9 @@ import type { PageServerLoad } from './$types';
 export const load: PageServerLoad = async ({ params }) => {
     const { username } = params;
     
-    // Basic validation
     if (!username || username.trim() === '') {
         throw error(404, 'User not found');
     }
-
-    // In a real app, you might validate the username format here
-    // and check if the user exists in your database
 
     return {
         username: username

--- a/src/routes/users/[username]/+page.svelte
+++ b/src/routes/users/[username]/+page.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
-	import { currentUser, isAuthenticated, clearAuth } from '$lib/stores/auth';
-	import { Button, Card, Alert, getUserProfileMetadata, type UserProfile } from '$lib';
+	import { isAuthenticated, clearAuth } from '$lib/stores/auth';
+	import { Button, Card, Alert, getUserProfileMetadata, type UserProfile, getUserProfile } from '$lib';
 	import type { PageProps } from './$types';
-  import { translateStore } from '$lib/strings';
+	import { translateStore } from '$lib/strings';
 
-  let { data }: PageProps = $props();
+	let { data }: PageProps = $props();
 
-  let userProfile: UserProfile = $state({
+	let userProfile: UserProfile = $state({
         username: data.username,
         id: undefined,
         total_boxes: 0,
@@ -23,7 +23,6 @@
 	onMount(async () => {
 		console.log('Profile page mounted');
 		console.log('isAuthenticated:', $isAuthenticated);
-		console.log('currentUser:', $currentUser);
 		console.log('localStorage auth_token:', localStorage.getItem('auth_token'));
 		console.log('localStorage current_user:', localStorage.getItem('current_user'));
 		
@@ -46,7 +45,9 @@
 			userProfile.total_items = metaData.total_items;
 			userProfile.total_labels = metaData.total_labels;
 
-			if ($currentUser?.username === userProfile.username) {
+			const currentUser = await getUserProfile()
+
+			if (currentUser.username === userProfile.username) {
 				isCurrentUser = true;
 			}
 		} catch (err: any) {
@@ -69,15 +70,6 @@
 			clearAuth();
 			goto('/');
 		}
-	}
-
-	function formatDate(dateString: string) {
-		if (!dateString) return 'N/A';
-		return new Date(dateString).toLocaleDateString('en-US', {
-			year: 'numeric',
-			month: 'long',
-			day: 'numeric'
-		});
 	}
 </script>
 


### PR DESCRIPTION
close #41 

Need some review on this.

This is what the pr does :

- Remove the flash related to the $isAuthentificated (which was stored in localStorage)
- Improve the way we handle `/user` page not storing the username inside svelte stores

**Root cause**

The main issue was that we stored every user related info (jwt, username) inside localStorage and svelte stores. That means that when render the page in a first place, the user was always considered as not connected (since it was not leaded at all)

**Solution**

The solution is to use cookie to store the JWT. Now, the jwt is passed directly to the server during the SSR. If the cookie is not found, then the user is considered as not connected. 

**About username and `/user` page**

Afterward, we were storing this in the localStorage too. This was a pretty bad way of doing this so here is the solution I came with : 

- We get the username using a new api routes (see [this](https://github.com/boks-boks-boks/api/pull/18)) to get the username using only the jwt
- We don't store the username **at all** in the app and always get it as needed using $effect rune

The only problem with this is that the username displayed on the `welcome back ...` strings is now resolve after the page render in a first time 

The solution i came with is to add this text in the {#if !loading} html tag so it only displayed when the loading is finished.

I don't know how we feel about that. To be honest, I think this whole solution looks a bit odd. Feel free to tell me what how you feel about this @axdelafuen 