### PR TITLE
Fix #63 - Labels and Profile pages not sync with JWT updates

### DIFF
--- a/src/lib/stores/labels.ts
+++ b/src/lib/stores/labels.ts
@@ -6,3 +6,7 @@ export const userLabels = writable<LabelModel[] | null>(null);
 export function setLabels(labels: LabelModel[]): void {
     userLabels.set(labels);
 }
+
+export function clearLabels(): void {
+    userLabels.set(null);
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -17,7 +17,7 @@
 	let username: string | null = $state(null)
 
 	$effect(() => {
-		if (!username && $isAuthenticated) {
+		if ($isAuthenticated) {
 			getUserProfile().then(userProfile => {
 				username = userProfile.username
 			})

--- a/src/routes/users/[username]/+page.svelte
+++ b/src/routes/users/[username]/+page.svelte
@@ -5,6 +5,7 @@
 	import { Button, Card, Alert, getUserProfileMetadata, type UserProfile, getUserProfile } from '$lib';
 	import type { PageProps } from './$types';
 	import { translateStore } from '$lib/strings';
+    import { clearLabels } from '$lib/stores/labels';
 
 	let { data }: PageProps = $props();
 
@@ -23,8 +24,6 @@
 	onMount(async () => {
 		console.debug('Profile page mounted');
 		console.debug('isAuthenticated:', $isAuthenticated);
-		console.debug('localStorage auth_token:', localStorage.getItem('auth_token'));
-		console.debug('localStorage current_user:', localStorage.getItem('current_user'));
 		
 		// Check if user is authenticated
 		if (!$isAuthenticated) {
@@ -63,11 +62,13 @@
 	function handleLogout() {
 		try {
 			clearAuth();
+			clearLabels();
 			goto('/');
 		} catch (err) {
 			console.error('Logout failed:', err);
 			// Still clear auth even if server logout fails
 			clearAuth();
+			clearLabels();
 			goto('/');
 		}
 	}


### PR DESCRIPTION
close #63 

**Context:**

The original issue suggested a problem with the JWT token not being refreshed for the user identity. After further investigation, the JWT itself was working correctly. The actual issue was that some data remained in memory after logout, since the page was not refreshed. As a result, Svelte stores (and related runes) continued to hold outdated user data.

**Fix:**

Added a `clear` step on logout to reset stored data.

Removed some API request checks that were intended to reduce calls but ended up causing desynchronization when a user switched accounts.

**Alternatives?**

This approach ensures that stale data is cleared properly.
Another possible solution would be to force a full page refresh on logout, which would automatically clear all Svelte stores/runes across the site.